### PR TITLE
chore: Drop broken heroku deployment reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Official guide on how to add authentication to Rails with Clerk.dev
 
 ## Getting started on Heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/clerkinc/clerk-rails-starter)
-
 Get your `CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` environment variables from [Clerk Dashboard](https://dashboard.clerk.dev).
 
 ## Getting started locally


### PR DESCRIPTION
Dropped the reference from the README since we no longer maintain the Heroku deployment of the Clerk Rails Starter